### PR TITLE
load more pv data

### DIFF
--- a/nowcasting_forecast/config/mvp_v2.yaml
+++ b/nowcasting_forecast/config/mvp_v2.yaml
@@ -57,6 +57,9 @@ input_data:
   #--------- PV --------
   pv:
     is_live: True
+    live_interpolate_minutes: 60
+    live_load_extra_minutes: 30
+
 
 output_data:
   filepath: ./batches/

--- a/nowcasting_forecast/config/mvp_v2.yaml
+++ b/nowcasting_forecast/config/mvp_v2.yaml
@@ -60,7 +60,6 @@ input_data:
     live_interpolate_minutes: 60
     live_load_extra_minutes: 30
 
-
 output_data:
   filepath: ./batches/
 process:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ sqlalchemy
 psycopg2-binary
 numpy
 click
-nowcasting_dataset==3.3.18
+nowcasting_dataset==3.3.19
 nowcasting_dataloader==1.8.38
 nowcasting_datamodel==0.0.53
 fsspec

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ sqlalchemy
 psycopg2-binary
 numpy
 click
-nowcasting_dataset==3.3.14
+nowcasting_dataset==3.3.18
 nowcasting_dataloader==1.8.38
 nowcasting_datamodel==0.0.53
 fsspec

--- a/tests/models/cnn/test_run.py
+++ b/tests/models/cnn/test_run.py
@@ -3,9 +3,9 @@
 import os
 import tempfile
 
-from freezegun import freeze_time
 import xarray as xr
 import zarr
+from freezegun import freeze_time
 
 import nowcasting_forecast
 from nowcasting_forecast.batch import make_batches
@@ -15,7 +15,7 @@ from nowcasting_forecast.models.cnn.model import Model
 from nowcasting_forecast.models.utils import general_forecast_run_all_batches
 
 
-@freeze_time('2022-01-01 12:00')
+@freeze_time("2022-01-01 12:00")
 def test_run(
     nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data, db_session, input_data_last_updated
 ):

--- a/tests/models/cnn/test_run.py
+++ b/tests/models/cnn/test_run.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 
+from freezegun import freeze_time
 import xarray as xr
 import zarr
 
@@ -14,6 +15,7 @@ from nowcasting_forecast.models.cnn.model import Model
 from nowcasting_forecast.models.utils import general_forecast_run_all_batches
 
 
+@freeze_time('2022-01-01 12:00')
 def test_run(
     nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data, db_session, input_data_last_updated
 ):

--- a/tests/models/cnn/test_run.py
+++ b/tests/models/cnn/test_run.py
@@ -3,9 +3,7 @@
 import os
 import tempfile
 
-import xarray as xr
 import zarr
-from freezegun import freeze_time
 
 import nowcasting_forecast
 from nowcasting_forecast.batch import make_batches
@@ -15,7 +13,6 @@ from nowcasting_forecast.models.cnn.model import Model
 from nowcasting_forecast.models.utils import general_forecast_run_all_batches
 
 
-@freeze_time("2022-01-01 12:00")
 def test_run(
     nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data, db_session, input_data_last_updated
 ):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+from freezegun import freeze_time
 import xarray as xr
 import zarr
 from nowcasting_dataset.config.load import load_yaml_configuration
@@ -63,6 +64,7 @@ def test_make_batches_mvp_v2_just_sat_data(sat_data):
         _ = Satellite(sat)
 
 
+@freeze_time('2022-01-01 12:00')
 def test_make_batches_mvp_v2(nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data):
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -3,7 +3,6 @@ import tempfile
 
 import xarray as xr
 import zarr
-from freezegun import freeze_time
 from nowcasting_dataset.config.load import load_yaml_configuration
 from nowcasting_dataset.config.save import save_yaml_configuration
 from nowcasting_dataset.data_sources.pv.pv_model import PV
@@ -64,7 +63,6 @@ def test_make_batches_mvp_v2_just_sat_data(sat_data):
         _ = Satellite(sat)
 
 
-@freeze_time("2022-01-01 12:00")
 def test_make_batches_mvp_v2(nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data):
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -80,6 +78,7 @@ def test_make_batches_mvp_v2(nwp_data, pv_yields_and_systems, sat_data, hrv_sat_
         with zarr.ZipStore(sat_path) as store:
             sat_data.to_zarr(store, compute=True)
         os.environ["SAT_PATH"] = sat_path
+
 
         make_batches(
             config_filename="nowcasting_forecast/config/mvp_v2.yaml", temporary_dir=temp_dir

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,9 +1,9 @@
 import os
 import tempfile
 
-from freezegun import freeze_time
 import xarray as xr
 import zarr
+from freezegun import freeze_time
 from nowcasting_dataset.config.load import load_yaml_configuration
 from nowcasting_dataset.config.save import save_yaml_configuration
 from nowcasting_dataset.data_sources.pv.pv_model import PV
@@ -64,7 +64,7 @@ def test_make_batches_mvp_v2_just_sat_data(sat_data):
         _ = Satellite(sat)
 
 
-@freeze_time('2022-01-01 12:00')
+@freeze_time("2022-01-01 12:00")
 def test_make_batches_mvp_v2(nwp_data, pv_yields_and_systems, sat_data, hrv_sat_data):
 
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
# Pull Request

## Description

Load more PV data, load extra 30 mins, and interpolate the full hour. Note the pV history length is 30 mins already

Fixes #95 

## How Has This Been Tested?

Unittests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
