### PR TITLE
nowcasting_dataset==3.7.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 click
 nowcasting_datamodel==1.4.0
 pandas==1.5.3
-nowcasting_dataset==3.7.23
+nowcasting_dataset==3.7.24
 nowcasting_dataloader==2.0.5
 fsspec
 ocf_blosc2


### PR DESCRIPTION
# Pull Request

## Description

Upgrade nowcasting_Dataset, dont get ide of rows of nans

Helps with https://github.com/openclimatefix/nowcasting_forecast/issues/199
## How Has This Been Tested?
CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
